### PR TITLE
Get LastPath from Follower and Get Path ID

### DIFF
--- a/src/main/java/com/pedropathing/follower/Follower.java
+++ b/src/main/java/com/pedropathing/follower/Follower.java
@@ -63,6 +63,7 @@ import com.qualcomm.robotcore.util.ElapsedTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * This is the Follower class. It handles the actual following of the paths and all the on-the-fly
@@ -91,6 +92,7 @@ public class Follower {
     private Pose closestPose;
 
     private Path currentPath;
+    private Path lastPath;
 
     private PathChain currentPathChain;
 
@@ -833,6 +835,7 @@ public class Follower {
      * This resets the PIDFs and stops following the current Path.
      */
     public void breakFollowing() {
+        if (currentPath != null) lastPath = currentPath;
         teleopDrive = false;
         setMotorsToFloat();
         holdingPosition = false;
@@ -1222,6 +1225,15 @@ public class Follower {
      */
     public Path getCurrentPath() {
         return currentPath;
+    }
+
+    /**
+     * This returns the last Path that the Follower was following. This can be null.
+     *
+     * @return returns the last Path.
+     */
+    public Path getLastPath() {
+        return lastPath;
     }
 
     /**

--- a/src/main/java/com/pedropathing/pathgen/Path.java
+++ b/src/main/java/com/pedropathing/pathgen/Path.java
@@ -2,6 +2,7 @@ package com.pedropathing.pathgen;
 
 import com.pedropathing.follower.FollowerConstants;
 import com.pedropathing.localization.Pose;
+import java.util.UUID;
 
 import java.util.ArrayList;
 
@@ -16,6 +17,8 @@ import java.util.ArrayList;
  * @version 1.0, 3/10/2024
  */
 public class Path {
+    private final UUID id;
+
     private final BezierCurve curve;
 
     private double startHeading;
@@ -71,6 +74,7 @@ public class Path {
      */
     public Path(BezierCurve curve) {
         this.curve = curve;
+        this.id = UUID.randomUUID();
     }
 
     /**
@@ -500,5 +504,14 @@ public class Path {
      */
     public double[][] getDashboardDrawingPoints() {
         return curve.getDashboardDrawingPoints();
+    }
+
+    /**
+     * Returns the unique identifier (UUID) of this path.
+     *
+     * @return the UUID of the path
+     */
+    public UUID getId() {
+        return id;
     }
 }


### PR DESCRIPTION
Hello,
I'm a member of team 17801, XMachine. In our implementation of the PedroPathing follower, we've encountered challenges with retrieving the last followed path, primarily due to the current structure of the code. To address this, we need to modify the PedroPathing system to allow us to track the last followed path and assign unique identifiers to each path.

I've made an effort to maintain compatibility with the existing system, so in theory, these changes should not affect current users' workflows.